### PR TITLE
Fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,20 @@ matrix:
 #  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
 ## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'import Pkg; Pkg.build(); Pkg.test(; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'using Pkg, LibGit2;
+              user_regs = joinpath(DEPOT_PATH[1],"registries");
+              mkpath(user_regs);
+              all_registries = Dict("General" => "https://github.com/JuliaRegistries/General.git",
+                            "HolyLabRegistry" => "git@github.com:HolyLab/HolyLabRegistry.git");
+              Base.shred!(LibGit2.CachedCredentials()) do creds
+                for (reg, url) in all_registries
+                  path = joinpath(user_regs, reg);
+                  LibGit2.with(Pkg.GitTools.clone(url, path; header = "registry $reg from $(repr(url))", credentials = creds)) do repo end
+                end
+              end'
+  - julia -e 'using Pkg; Pkg.build(); Pkg.test("RegisterQD"; coverage=false)'
 
 after_success:
   # push coverage results to Codecov

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -5,6 +5,7 @@ using RegisterMismatch
 using RegisterCore #just for indmin_mismatch?
 using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays
+using LinearAlgebra
 
 include("util.jl")
 include("translations.jl")
@@ -14,7 +15,7 @@ include("affine.jl")
 
 export qd_translate,
         qd_rigid,
-        qd_affine,
+        qd_affine
         #grid_rotations,
         #rotation_gridsearch
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using RegisterQD
 using Test
 
-#include("qd_random.jl") #fails as of Julia 0.7 transition
+include("qd_random.jl")
 include("qd_standard.jl")
 #include("gridsearch.jl")


### PR DESCRIPTION
This fixes #1. The performance enhancements are almost entirely from https://github.com/HolyLab/RFFT.jl/pull/7. The correctness fixes come from eliminating some calls to `centered` on `fixed`. The change with Julia 0.7/1.0 is that OffsetArrays axes are themselves offset: that is to say, formerly one had

```julia
# julia 0.6
julia> a = OffsetArray(1:5, -2:2)
OffsetArrays.OffsetArray{Int64,1,UnitRange{Int64}} with indices -2:2:
 1
 2
 3
 4
 5

julia> indices(a)
(-2:2,)
```
and now one has
```julia
# julia 1.1
julia> using OffsetArrays

julia> a = OffsetArray(1:5, -2:2)
OffsetArray(::UnitRange{Int64}, -2:2) with eltype Int64 with indices -2:2:
 1
 2
 3
 4
 5

julia> axes(a)
(Base.IdentityUnitRange(-2:2),)
```

`Base.IdentityUnitRange` is called `Base.Slice` in julia 1.0; a nice trick is that `OffsetArrays.IdentityUnitRange` returns the correct one for your version of Julia. Both of these behave a lot like [IdentityRanges](https://github.com/JuliaArrays/IdentityRanges.jl), whose README explains the concept. I need to separately look into why `centered` did something bad (you'd hope it would be a no-op on something that was already zero-centered), but this gets the tests here working and is a good model to follow for real-world applications.