### PR TITLE
RFC: rework qd_rigid to always return a rigid transformation

### DIFF
--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -8,6 +8,8 @@ using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays, OffsetArrays
 using LinearAlgebra
 
+using Images.ImageTransformations: CornerIterator
+
 const VecLike = Union{AbstractVector{<:Number}, Tuple{Number, Vararg{Number}}}
 
 include("util.jl")

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -16,8 +16,20 @@ include("gridsearch.jl")
 
 export qd_translate,
         qd_rigid,
-        qd_affine
+        qd_affine,
+        arrayscale,
         grid_rotations,
         rotation_gridsearch
+
+# Deprecations
+function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I; kwargs...)
+    error("""
+    `qd_rigid` has fundamentally changed. For the new syntax, see the help (`?qd_rigid`).
+    In particular, note that the transformation is now returned in *physical*
+    units rather than *array-index* units---if you were using something different
+    from the identity matrix for `SD`, this is a change in behavior.
+    As a consequence, your old results may not be comparable with your new results.
+    """)
+end
 
 end # module

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -8,6 +8,8 @@ using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays, OffsetArrays
 using LinearAlgebra
 
+const VecLike = Union{AbstractVector{<:Number}, Tuple{Number, Vararg{Number}}}
+
 include("util.jl")
 include("translations.jl")
 include("rigid.jl")
@@ -22,13 +24,14 @@ export qd_translate,
         rotation_gridsearch
 
 # Deprecations
-function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I; kwargs...)
+function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike}, minwidth_rot::VecLike, SD::AbstractMatrix=I; kwargs...)
     error("""
-    `qd_rigid` has fundamentally changed. For the new syntax, see the help (`?qd_rigid`).
+    `qd_rigid` has a new syntax, see the help (`?qd_rigid`).
     In particular, note that the transformation is now returned in *physical*
     units rather than *array-index* units---if you were using something different
     from the identity matrix for `SD`, this is a change in behavior.
     As a consequence, your old results may not be comparable with your new results.
+    See also [`arrayscale`](@ref).
     """)
 end
 

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -1,48 +1,81 @@
-update_SD(SD, tfm::Union{LinearMap, AffineMap}) = update_SD(SD, tfm.linear)
-update_SD(SD, tfm::Transformation) = SD
-update_SD(SD::AbstractArray, m::StaticArray) = update_SD(SD, Array(m))
-update_SD(SD::AbstractArray, m::AbstractArray) = m\SD*m
+## Transformations
 
-#rotation only
-function rot(theta, img::AbstractArray{T,2}, SD=I) where {T}
-    length(theta) == 1 || throw(DimensionMismatch("expected 1 parameters got $(length(thetas))"))
-    rotm = SD\RotMatrix(theta...)*SD
-    SDS = SMatrix{2,2}(SD)
-    return LinearMap(SMatrix{2,2}(rotm))
+# Rotation only
+"""
+    R2 = rot(θ)
+
+Calculate a two-dimensional rotation transformation `R2`.
+`θ` is the angle of rotation around the `z` axis applied to the `xy` plane.
+"""
+rot(θ::Number) = LinearMap(RotMatrix(θ))
+
+"""
+    R3 = rot(qx, qy, qz)
+
+    Calculate a three-dimensional rotation transformation from the supplied parameters.
+    `qx`, `qy`, and `qz` specify the rotation via the components of the corresponding
+    [unit quaternion](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation).
+    Briefly, `R3` is a rotation around the axis specified by the unit vector `q/|q|`
+    (where `q` is the 3-component vector), with an angle `θ` given by `sin(θ/2) = |q|`.
+    If `|q| > 1`, `rot` returns `nothing` instead of erroring.
+"""
+function rot(qx::Number, qy::Number, qz::Number)
+    # Unit-quaternion parametrization
+    r2 = qx^2 + qy^2 + qz^2
+    r2 > 1 && return nothing
+    qr = sqrt(1 - r2)
+    R = @SMatrix([1 - 2*(qy^2 + qz^2)  2*(qx*qy - qz*qr)    2*(qx*qz + qy*qr);
+                  2*(qx*qy + qz*qr)    1 - 2*(qx^2 + qz^2)  2*(qy*qz - qx*qr);
+                  2*(qx*qz - qy*qr)    2*(qy*qz + qx*qr)    1 - 2*(qx^2 + qy^2)])
+    return LinearMap(RotMatrix(R))
 end
-function rot(thetas, img::AbstractArray{T,3}, SD=I) where {T}
-    length(thetas) == 3 || throw(DimensionMismatch("expected 3 parameters, got $(length(thetas))"))
-    θx, θy, θz = thetas
-    rotm = RotMatrix(RotXYZ(θx,θy,θz))
-    SDS = SMatrix{3,3}(SD)
-    rotm = SDS\rotm*SDS
-    return LinearMap(SMatrix{3,3}(rotm))
+
+#rotation + translation
+tfmrigid(dx::Number, dy::Number, θ::Number) = Translation(dx, dy) ∘ rot(θ)
+
+tfmrigid(dx::Number, dy::Number, dz::Number, qx::Number, qy::Number, qz::Number) =
+    Translation(dx, dy, dz) ∘ rot(qx, qy, qz)
+
+## Transformations supplied as vectors, for which we pass the array so we can infer the dimensionality
+
+@noinline dimcheck(v, lv) = length(v) == lv || throw(DimensionMismatch("expected $lv parameters, got $(length(v))"))
+
+function rot(theta, img::AbstractArray{T,2}) where {T}
+    dimcheck(theta, 1)
+    return rot(theta[1])
 end
+
+function rot(qs, img::AbstractArray{T,3}) where {T}
+    dimcheck(qs, 3)
+    qx, qy, qz = qs
+    return rot(qx, qy, qz)
+end
+
+function tfmrigid(params, img::AbstractArray{T,2}) where {T}
+    dimcheck(params, 3)
+    dx, dy, θ = params
+    return tfmrigid(dx, dy, θ)
+end
+
+function tfmrigid(params, img::AbstractArray{T,3}) where {T}
+    dimcheck(params, 6)
+    dx, dy, dz, qx, qy, qz = params
+    return tfmrigid(dx, dy, dz, qx, qy, qz)
+end
+
+## Computing mismatch
 
 #rotation + shift, fast because it uses fourier method for shift
 function rigid_mm_fast(theta, mxshift, fixed, moving, thresh, SD; initial_tfm=IdentityTransformation())
-    tfm = initial_tfm ∘ rot(theta, moving, update_SD(SD, initial_tfm))
+    tfm = arrayscale(initial_tfm ∘ rot(theta, moving), SD)
     moving, fixed = warp_and_intersect(moving, fixed, tfm)
     bshft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity)
     return mm
 end
 
-#rotation + translation
-function tfmrigid(params, img::AbstractArray{T,2}, SD=Matrix(1.0*I,2,2)) where {T}
-    length(params) == 3 || throw(DimensionMismatch("expected 3 parameters, got $(length(params))"))
-    dx, dy, θ = params
-    rt = rot(θ, img, SD)
-    return Translation(dx, dy) ∘ rt
-end
-function tfmrigid(params, img::AbstractArray{T,3}, SD=Matrix(1.0*I,3,3)) where {T}
-    length(params) == 6 || throw(DimensionMismatch("expected 6 parameters, got $(length(params))"))
-    dx, dy, dz, θx, θy, θz =  params
-    rt = rot((θx, θy, θz), img, SD)
-    return Translation(dx, dy, dz) ∘ rt
-end
 #rotation + shift, slow because it warps for every rotation and shift
 function rigid_mm_slow(params, fixed, moving, thresh, SD; initial_tfm=IdentityTransformation())
-    tfm = initial_tfm ∘ tfmrigid(params, moving, update_SD(SD, initial_tfm))
+    tfm = arrayscale(initial_tfm ∘ tfmrigid(params, moving), SD)
     moving, fixed = warp_and_intersect(moving, fixed, tfm)
     mm = mismatch0(fixed, moving; normalization=:intensity)
     return ratio(mm, thresh, Inf)
@@ -59,9 +92,9 @@ function qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD;
     root_coarse, x0coarse = _analyze(f, lower, upper;
                                      minwidth=minwidth_rot, print_interval=100, maxevals=5e4, kwargs..., atol=0, rtol=1e-3)
     box_coarse = minimum(root_coarse)
-    tfmcoarse0 = initial_tfm ∘ rot(position(box_coarse, x0coarse), moving, update_SD(SD, initial_tfm))
-    best_shft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=tfmcoarse0)
-    tfmcoarse = tfmcoarse0 ∘ Translation(best_shft)
+    tfmcoarse0 = initial_tfm ∘ rot(position(box_coarse, x0coarse), moving)
+    best_shft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=arrayscale(tfmcoarse0, SD))
+    tfmcoarse = tfmcoarse0 ∘ pscale(Translation(best_shft), SD)
     return tfmcoarse, mm
 end
 
@@ -78,33 +111,63 @@ function qd_rigid_fine(fixed, moving, mxrot, minwidth_rot, SD;
     minwidth = vcat(minwidth_shfts, minwidth_rot)
     root, x0 = _analyze(f, lower, upper; minwidth=minwidth, print_interval=100, maxevals=5e4, kwargs...)
     box = minimum(root)
-    tfmfine = initial_tfm ∘ tfmrigid(position(box, x0), moving, update_SD(SD, initial_tfm))
+    tfmfine = initial_tfm ∘ tfmrigid(position(box, x0), moving)
     return tfmfine, value(box)
 end
 
 """
-`tform, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I;  thresh=thresh, initial_tfm=IdentityTransformation(), kwargs...)`
-optimizes a rigid transformation (rotation + shift) to minimize the mismatch between `fixed` and
-`moving` using the QuadDIRECT algorithm.  The algorithm is run twice: the first step uses a fourier method to speed up
-the search for the best whole-pixel shift.  The second step refines the search for sub-pixel accuracy. `kwargs...` can include any
-keyword argument that can be passed to `QuadDIRECT.analyze`. It's recommended that you pass your own stopping criteria when possible
-(i.e. `rtol`, `atol`, and/or `fvalue`).  If you provide `rtol` and/or `atol` they will apply only to the second (fine) step of the registration;
-the user may not adjust these criteria for the coarse step.
+    tform, mm = qd_rigid(fixed, moving, mxshift, mxrot;
+                         SD=I, minwidth_rot=default_minwidth_rot(fixed, SD),
+                         thresh=thresh, initial_tfm=IdentityTransformation(), kwargs...)
 
-The rotation returned will be centered on the origin-of-coordinates, i.e. (0,0) for a 2D image.  Usually it is more natural to consider rotations
-around the center of the image.  If you would like `mxrot` and the returned rotation to act relative to the center of the image, then you must
-move the origin to the center of the image by calling `centered(img)` from the `ImageTransformations` package.  Call `centered` on both the
-fixed and moving image to generate the `fixed` and `moving` that you provide as arguments.  If you later want to apply the returned transform
-to an image you must remember to call `centered` on that image as well.  Alternatively you can re-encode the transformation in terms of a
+Optimize a rigid transformation (rotation + shift) to minimize the mismatch between `fixed` and
+`moving` using the QuadDIRECT algorithm.  The algorithm is run twice: the first step finds the optimal rotation,
+using a fourier method to speed up the search for the best whole-pixel shift.
+The second step performs the rotation + shift in combination to obtain sub-pixel accuracy.
+Any `NaN`-valued pixels are not included in the mismatch; you can use this to mask out
+any regions of `fixed` that you don't want to align against.
+
+`mxshift` is the maximum-allowed translation, in units of array indices. It can be passed
+as a vector or tuple.
+`mxrot` is the maximum-allowed rotation, in radians for 2d or
+[quaternion-units](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation) for 3d.
+See [`RegisterQD.rot`](@ref) for more information.
+`minwidth_rot` optionally specifies the lower limit of resolution for the rotation;
+the default is a rotation that moves corner elements by 0.1 pixel.
+
+`kwargs...` can include any keyword argument that can be passed to `QuadDIRECT.analyze`.
+It's recommended that you pass your own stopping criteria when possible
+(i.e. `rtol`, `atol`, and/or `fvalue`).
+If you provide `rtol` and/or `atol` they will apply only to the second (fine) step of the registration;
+there is currently no way to adjust these criteria for the coarse step.
+
+The rotation returned will be centered on the origin-of-coordinates, i.e. (0,0) for a 2D image.
+Usually it is more natural to consider rotations around the center of the image.
+If you would like `mxrot` and the returned rotation to act relative to the center of the image,
+then you must move the origin to the center of the image by calling `centered(img)` from the
+`ImageTransformations` package.
+Call `centered` on both the fixed and moving image to generate the `fixed` and `moving` that you provide as arguments.
+If you later want to apply the returned transform to an image you must remember to call `centered`
+on that image as well.  Alternatively you can re-encode the transformation in terms of a
 different origin by calling `recenter(tform, newctr)` where `newctr` is the displacement of the new center from the old center.
 
 Use `SD` if your axes are not uniformly sampled, for example `SD = diagm(voxelspacing)` where `voxelspacing`
-is a vector encoding the spacing along all axes of the image. `thresh` enforces a certain amount of sum-of-squared-intensity overlap between
-the two images; with non-zero `thresh`, it is not permissible to "align" the images by shifting one entirely out of the way of the other.
+is a vector encoding the spacing along all axes of the image.
+See [`arrayscale`](@ref) for more information about `SD`.
+
+`thresh` enforces a certain amount of sum-of-squared-intensity overlap between
+the two images; with non-zero `thresh`, it is not permissible to "align" the images by
+shifting one entirely out of the way of the other. The default value for `thresh` is 10%
+of the sum-of-squared-intensity of `fixed`.
 
 If you have a good initial guess at the solution, pass it with the `initial_tfm` kwarg to jump-start the search.
+
+Both the output `tfm` and any `initial_tfm` are represented in *physical* coordinates;
+as long as `initial_tfm` is a rigid transformation, `tfm` will be a pure rotation+translation.
+If `SD` is not the identity, use `arrayscale` before applying the result to `moving`.
 """
-function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=Matrix(1.0*I, ndims(fixed), ndims(fixed));
+function qd_rigid(fixed, moving, mxshift, mxrot, SD=I;
+                  minwidth_rot=default_minwidth_rot(CartesianIndices(fixed), SD),
                   thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                   initial_tfm=IdentityTransformation(),
                   print_interval=100,
@@ -113,7 +176,7 @@ function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=Matrix(1.0*I, 
     mxrot = [mxrot...]
     print_interval < typemax(Int) && print("Running coarse step\n")
     tfm_coarse, mm_coarse = qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD; initial_tfm=initial_tfm, thresh=thresh, print_interval=print_interval, kwargs...)
-    print_interval < typemax(Int) && print("Running fine step\n")
+    print_interval < typemax(Int) && print("Obtained mismatch $mm_coards from coarse step, running fine step\n")
     final_tfm, mm_fine = qd_rigid_fine(fixed, moving, mxrot./2, minwidth_rot, SD; initial_tfm=tfm_coarse, thresh=thresh, print_interval=print_interval, kwargs...)
     return final_tfm, mm_fine
 end

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -151,8 +151,9 @@ If you later want to apply the returned transform to an image you must remember 
 on that image as well.  Alternatively you can re-encode the transformation in terms of a
 different origin by calling `recenter(tform, newctr)` where `newctr` is the displacement of the new center from the old center.
 
-Use `SD` if your axes are not uniformly sampled, for example `SD = diagm(voxelspacing)` where `voxelspacing`
-is a vector encoding the spacing along all axes of the image.
+Use `SD` ("spatial displacements") if your axes are not uniformly sampled, for example
+`SD = diagm(voxelspacing)` where `voxelspacing` is a vector encoding the spacing along all axes
+of the image.
 See [`arrayscale`](@ref) for more information about `SD`.
 
 `thresh` enforces a certain amount of sum-of-squared-intensity overlap between
@@ -166,7 +167,8 @@ Both the output `tfm` and any `initial_tfm` are represented in *physical* coordi
 as long as `initial_tfm` is a rigid transformation, `tfm` will be a pure rotation+translation.
 If `SD` is not the identity, use `arrayscale` before applying the result to `moving`.
 """
-function qd_rigid(fixed, moving, mxshift, mxrot, SD=I;
+function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike};
+                  SD::AbstractMatrix=I,
                   minwidth_rot=default_minwidth_rot(CartesianIndices(fixed), SD),
                   thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                   initial_tfm=IdentityTransformation(),

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -176,7 +176,7 @@ function qd_rigid(fixed, moving, mxshift, mxrot, SD=I;
     mxrot = [mxrot...]
     print_interval < typemax(Int) && print("Running coarse step\n")
     tfm_coarse, mm_coarse = qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD; initial_tfm=initial_tfm, thresh=thresh, print_interval=print_interval, kwargs...)
-    print_interval < typemax(Int) && print("Obtained mismatch $mm_coards from coarse step, running fine step\n")
+    print_interval < typemax(Int) && print("Obtained mismatch $mm_coarse from coarse step, running fine step\n")
     final_tfm, mm_fine = qd_rigid_fine(fixed, moving, mxrot./2, minwidth_rot, SD; initial_tfm=tfm_coarse, thresh=thresh, print_interval=print_interval, kwargs...)
     return final_tfm, mm_fine
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -116,7 +116,7 @@ function default_minwidth_rot(I::CartesianIndices{2}, SD; d=0.1)
     for c in CornerIterator(I)
         Δc = T*SVector(Tuple(c))
         for dc in Δc
-            θ = min(θ, d/dc)
+            θ = min(θ, abs(d/dc))
         end
     end
     return (θ,)

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -56,7 +56,7 @@ using Test, TestImages
     minwidth_rot = [0.0002]
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, maxevals=1000, rtol=0, fvalue=1e-8)
+    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0, fvalue=1e-8)
 
     @test sum(abs.(tfm0.linear - tfm.linear)) < 1e-3
 
@@ -73,7 +73,7 @@ using Test, TestImages
     minwidth_rot = fill(0.0002, 3)
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, maxevals=1000, rtol=0)
+    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0)
 
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(RotXYZ(tfm.linear)[:], tfm.translation))) < 0.1
 
@@ -120,7 +120,7 @@ using Test, TestImages
 
     #@test mm <= 1e-4
     #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
-    
+
     #not random
     #moving = zeros(10,10,10);
     #moving[5:7, 5:7, 5:7] = 1.0
@@ -156,7 +156,7 @@ end #tests with random images
     mktemp() do path, io
         redirect_stdout(io) do
             qd_translate(a, b, (2,2); print_interval=typemax(Int))
-            qd_rigid(ca, cb, mxshift, mxrot, minwidth_rot; print_interval=typemax(Int))
+            qd_rigid(ca, cb, mxshift, mxrot; print_interval=typemax(Int))
             qd_affine(ca, cb, mxshift; print_interval=typemax(Int))
         end
         flush(io)

--- a/test/qd_standard.jl
+++ b/test/qd_standard.jl
@@ -47,7 +47,7 @@ end
     mxshift = (100,100) #make sure this isn't too small
     tform, mm = qd_translate(fixed, moving, mxshift; maxevals=1000, rtol=0, fvalue=0.0003)
     tfmtest(tfm, tform)
-    
+
     #Rigid transform
     SD = Matrix{Float64}(LinearAlgebra.I, 2, 2)
     tfm = Translation(@SVector([14, 17]))∘LinearMap(RotMatrix(0.3)) #no distortion for now
@@ -55,14 +55,14 @@ end
     mxshift = (100,100) #make sure this isn't too small
     mxrot = (0.5,)
     minwidth_rot = fill(0.002, 3)
-    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot, minwidth_rot, SD; maxevals=1000, rtol=0, fvalue=0.0002)
+    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot; SD=SD, maxevals=1000, rtol=0, fvalue=0.0002)
     tfmtest(tfm, tform)
     #with anisotropic sampling
     SD = Matrix(Diagonal([0.5; 1.0]))
     tfm = Translation(@SVector([14.3, 17.8]))∘LinearMap(SD\RotMatrix(0.3)*SD)
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot, minwidth_rot, SD; maxevals=1000, rtol=0, fvalue=0.0002)
-    tfmtest(tfm, tform)
+    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot; SD=SD, maxevals=1000, rtol=0, fvalue=0.0002)
+    tfmtest(tfm, arrayscale(tform, SD))
 
     #Affine transform
     tfm = Translation(@SVector([14, 17]))∘LinearMap(RotMatrix(0.01))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ImageMagick
 using RegisterQD
 using Test
 
+include("util.jl")
 include("qd_random.jl")
 include("qd_standard.jl")
 include("gridsearch.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,16 @@
+@testset "default_minwidth_rot" begin
+    img = rand(3, 10)
+    ci = CartesianIndices(img)
+    θ = RegisterQD.default_minrot(ci)
+    @test θ ≈ 0.01 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [1 0; 0 2])
+    @test θ ≈ 0.005 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [3 0; 0 1])
+    @test θ ≈ 0.007 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [10 0; 0 1])
+    @test θ ≈ 0.01/3 rtol=0.1
+    img = rand(3, 10, 5)
+    ci = CartesianIndices(img)
+    θ = RegisterQD.default_minrot(ci)
+    @test θ ≈ 0.1/sqrt(3^2 + 10^2 + 5^2) rtol=1e-3
+end


### PR DESCRIPTION
This is a sketch of a solution to #10. I haven't even tried running the tests yet (they are guaranteed to fail), but I thought it would be good to put something concrete up for further discussion. The key breaking change here is that `qd_rigid` always returns a rigid transformation, at the cost of no longer returning a transformation that you can *naively* apply to your array if it has non-uniform sampling along its axes. The new exported function `arrayscale` incorporates `SD` to produce a transformation suitable for array-index units. 

I personally think this is probably worth it because of the following work flow:

- perform motion correction on an image sequence
- discover that a small subset of the images don't have very good alignment
- try to fix the broken cases using an initial guess based on the preceding and/or succeeding stack(s)

I think this change makes it substantially easier to implement this work flow, and you know that your rigid initial guess will still return a rigid result.

Do not merge. Once we settle on a strategy I (perhaps in collaboration with others) will get this into a merge-worthy state.