### PR TITLE
Change alignment to always return a physical-space transformation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ julia:
   - 0.7
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# version 0.2
+
+## Breaking changes
+
+- For users of `SD` ("space directions"), an input that allows you to specify the spatial sampling of your input array, the meaning of the returned transformation has changed. The return value is now in "physical space" rather than in "array index space." Specifically, formerly the returned transformation included the consequences of any change of scale needed to apply the transformation to the supplied arrays: for a rotation matrix `R`, the return was `SD\(R*SD)`.
+Now just `R` gets returned. This means that a rigid transformation will now "look" rigid.
+This change fixes some formerly-significant problems for
+optimization when a known starting guess was available.
+Use the new `arrayscale` function just before warping to prepare a transformation for a particular array with nonisotropic sampling.

--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Test", "ImageMagick", "TestImages"]
+test = ["Test", "ImageMagick", "TestImages", "Random"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/o82s9bc4m8lgmgf5?svg=true)](https://ci.appveyor.com/project/Cody-G/registerqd-jl)
 [![codecov](https://codecov.io/gh/HolyLab/RegisterQD.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/HolyLab/RegisterQD.jl)
 
-This package exports 3 functions: `qd_translate`, `qd_rigid`, and `qd_affine`. `qd_translate` only supports translations and therefore offers the fewest degrees of freedom; `qd_affine` offers the most. In general, using more degrees of freedom allows you to solve harder optimization problems but also makes it harder to find the global optimum. Your best strategy is to permit no more degrees of freedom than needed to solve the problem.
+RegisterQD performs image registration using the global optimization routine [QuadDIRECT](https://github.com/timholy/QuadDIRECT.jl).
+Unlike many other registration packages, this is not "greedy" descent based on an initial guess---it attempts to find the globally-optimal alignment of your images.
+
+This package exports the following registration functions:
+- `qd_translate`: register images by shifting one with respect to another (translations only)
+- `qd_rigid`: register images using rotations and translations
+- `qd_affine`: register images using arbitrary affine transformations
+
+In general, using more degrees of freedom allows you to solve harder optimization problems, but also makes it harder to find the global optimum. Your best strategy is to permit no more degrees of freedom than needed to solve the problem.
 
 See the help on these functions for details about how to call them.
+
+Another important feature of this package is that it supports images that were sampled anisotropically. This is particularly common for three-dimensional biomedical imaging, where MRI and optical microscopy typically have one axis sampled at lower resolution.
+A rotation (from a rigid transformation) in physical space needs to be modified before applying it to an anisotropically-sampled image; see the `arrayscale` function for more information.
+
+**NOTE**: see NEWS.md for information about a recent breaking change.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
   #- julia_version: nightly
 
 platform:

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -8,6 +8,8 @@ using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays, OffsetArrays
 using LinearAlgebra
 
+using Images.ImageTransformations: CornerIterator
+
 const VecLike = Union{AbstractVector{<:Number}, Tuple{Number, Vararg{Number}}}
 
 include("util.jl")

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -16,8 +16,20 @@ include("gridsearch.jl")
 
 export qd_translate,
         qd_rigid,
-        qd_affine
+        qd_affine,
+        arrayscale,
         grid_rotations,
         rotation_gridsearch
+
+# Deprecations
+function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I; kwargs...)
+    error("""
+    `qd_rigid` has fundamentally changed. For the new syntax, see the help (`?qd_rigid`).
+    In particular, note that the transformation is now returned in *physical*
+    units rather than *array-index* units---if you were using something different
+    from the identity matrix for `SD`, this is a change in behavior.
+    As a consequence, your old results may not be comparable with your new results.
+    """)
+end
 
 end # module

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -8,6 +8,8 @@ using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays, OffsetArrays
 using LinearAlgebra
 
+const VecLike = Union{AbstractVector{<:Number}, Tuple{Number, Vararg{Number}}}
+
 include("util.jl")
 include("translations.jl")
 include("rigid.jl")
@@ -22,13 +24,14 @@ export qd_translate,
         rotation_gridsearch
 
 # Deprecations
-function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I; kwargs...)
+function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike}, minwidth_rot::VecLike, SD::AbstractMatrix=I; kwargs...)
     error("""
-    `qd_rigid` has fundamentally changed. For the new syntax, see the help (`?qd_rigid`).
+    `qd_rigid` has a new syntax, see the help (`?qd_rigid`).
     In particular, note that the transformation is now returned in *physical*
     units rather than *array-index* units---if you were using something different
     from the identity matrix for `SD`, this is a change in behavior.
     As a consequence, your old results may not be comparable with your new results.
+    See also [`arrayscale`](@ref).
     """)
 end
 

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -37,4 +37,14 @@ function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike},
     """)
 end
 
+function qd_affine(fixed, moving, mxshift, linmins, linmaxs, SD;
+                   thresh=0.5*sum(abs2.(fixed[.!(isnan.(fixed))])),
+                   initial_tfm=IdentityTransformation(),
+                   print_interval=100,
+                   kwargs...)
+           error("""
+           `qd_affine` has a new syntax, see the help (`?qd_affine`).
+           """)
+end #ad_affine
+
 end # module

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -28,12 +28,7 @@ export qd_translate,
 # Deprecations
 function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike}, minwidth_rot::VecLike, SD::AbstractMatrix=I; kwargs...)
     error("""
-    `qd_rigid` has a new syntax, see the help (`?qd_rigid`).
-    In particular, note that the transformation is now returned in *physical*
-    units rather than *array-index* units---if you were using something different
-    from the identity matrix for `SD`, this is a change in behavior.
-    As a consequence, your old results may not be comparable with your new results.
-    See also [`arrayscale`](@ref).
+    `qd_rigid` has a new syntax, see the help (`?qd_rigid`) and `NEWS.md`.
     """)
 end
 
@@ -42,9 +37,9 @@ function qd_affine(fixed, moving, mxshift, linmins, linmaxs, SD;
                    initial_tfm=IdentityTransformation(),
                    print_interval=100,
                    kwargs...)
-           error("""
-           `qd_affine` has a new syntax, see the help (`?qd_affine`).
-           """)
-end #ad_affine
+    error("""
+    `qd_affine` has a new syntax, see the help (`?qd_affine`) and `NEWS.md`.
+    """)
+end
 
 end # module

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -37,12 +37,13 @@ function qd_affine_coarse(fixed, moving, mxshift, linmins, linmaxs;
                           initial_tfm=IdentityTransformation(),
                           thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                           minwidth=default_lin_minwidths(moving),
+                          maxevals=5e4,
                           kwargs...)
     f(x) = affine_mm_fast(x, mxshift, fixed, moving, thresh, SD; initial_tfm=initial_tfm)
     upper = linmaxs
     lower = linmins
     root, x0 = _analyze(f, lower, upper;
-                        minwidth=minwidth, print_interval=100, maxevals=5e4, kwargs..., atol=0, rtol=1e-3)
+                        minwidth=minwidth, print_interval=100, maxevals=maxevals, kwargs..., atol=0, rtol=1e-3)
     box = minimum(root)
     params = position(box, x0)
     tfmcoarse0 = linmap(params, moving, initial_tfm)
@@ -56,6 +57,7 @@ function qd_affine_fine(fixed, moving, linmins, linmaxs;
                         initial_tfm=IdentityTransformation(),
                         thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                         minwidth_mat=default_lin_minwidths(fixed)./10,
+                        maxevals=5e4,
                         kwargs...)
     f(x) = affine_mm_slow(x, fixed, moving, thresh, SD; initial_tfm=initial_tfm)
     upper_shft = fill(2.0, ndims(fixed))
@@ -64,7 +66,7 @@ function qd_affine_fine(fixed, moving, linmins, linmaxs;
     minwidth_shfts = fill(0.01, ndims(fixed))
     minwidth = vcat(minwidth_shfts, minwidth_mat)
     root, x0 = _analyze(f, lower, upper;
-                        minwidth=minwidth, print_interval=100, maxevals=5e4, kwargs...)
+                        minwidth=minwidth, print_interval=100, maxevals=maxevals, kwargs...)
     box = minimum(root)
     params = position(box, x0)
     tfmfine = aff(params, moving, initial_tfm)

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -33,7 +33,7 @@ function affine_mm_slow(params, fixed, moving, thresh, SD; initial_tfm=IdentityT
 end
 
 function qd_affine_coarse(fixed, moving, mxshift, linmins, linmaxs;
-                            SD=Matrix(1.0*I,ndims(fixed),ndims(fixed)),
+                          SD=I,
                           initial_tfm=IdentityTransformation(),
                           thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                           minwidth=default_lin_minwidths(moving),
@@ -52,7 +52,7 @@ function qd_affine_coarse(fixed, moving, mxshift, linmins, linmaxs;
 end
 
 function qd_affine_fine(fixed, moving, linmins, linmaxs;
-                        SD=Matrix(1.0*I,ndims(fixed),ndims(fixed)),
+                        SD=I,
                         initial_tfm=IdentityTransformation(),
                         thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                         minwidth_mat=default_lin_minwidths(fixed)./10,
@@ -107,7 +107,7 @@ is a vector encoding the spacing along all axes of the image. `thresh` enforces 
 overlap between the two images; with non-zero `thresh`, it is not permissible to "align" the images by shifting one entirely out of the way of the other.
 """
 function qd_affine(fixed, moving, mxshift, linmins, linmaxs;
-                    SD=Matrix(1.0*I,ndims(fixed),ndims(fixed)),
+                   SD=I,
                    thresh=0.5*sum(abs2.(fixed[.!(isnan.(fixed))])),
                    initial_tfm=IdentityTransformation(),
                    print_interval=100,
@@ -128,7 +128,7 @@ function qd_affine(fixed, moving, mxshift, linmins, linmaxs;
 end
 
 function qd_affine(fixed, moving, mxshift;
-                    SD=Matrix(1.0*I,ndims(fixed),ndims(fixed)),
+                   SD=I,
                    thresh=0.5*sum(abs2.(fixed[.!(isnan.(fixed))])),
                    initial_tfm=IdentityTransformation(),
                    dmax = 0.05, ndmax = 0.05,

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -1,48 +1,81 @@
-update_SD(SD, tfm::Union{LinearMap, AffineMap}) = update_SD(SD, tfm.linear)
-update_SD(SD, tfm::Transformation) = SD
-update_SD(SD::AbstractArray, m::StaticArray) = update_SD(SD, Array(m))
-update_SD(SD::AbstractArray, m::AbstractArray) = m\SD*m
+## Transformations
 
-#rotation only
-function rot(theta, img::AbstractArray{T,2}, SD=I) where {T}
-    length(theta) == 1 || throw(DimensionMismatch("expected 1 parameters got $(length(thetas))"))
-    rotm = SD\RotMatrix(theta...)*SD
-    SDS = SMatrix{2,2}(SD)
-    return LinearMap(SMatrix{2,2}(rotm))
+# Rotation only
+"""
+    R2 = rot(θ)
+
+Calculate a two-dimensional rotation transformation `R2`.
+`θ` is the angle of rotation around the `z` axis applied to the `xy` plane.
+"""
+rot(θ::Number) = LinearMap(RotMatrix(θ))
+
+"""
+    R3 = rot(qx, qy, qz)
+
+    Calculate a three-dimensional rotation transformation from the supplied parameters.
+    `qx`, `qy`, and `qz` specify the rotation via the components of the corresponding
+    [unit quaternion](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation).
+    Briefly, `R3` is a rotation around the axis specified by the unit vector `q/|q|`
+    (where `q` is the 3-component vector), with an angle `θ` given by `sin(θ/2) = |q|`.
+    If `|q| > 1`, `rot` returns `nothing` instead of erroring.
+"""
+function rot(qx::Number, qy::Number, qz::Number)
+    # Unit-quaternion parametrization
+    r2 = qx^2 + qy^2 + qz^2
+    r2 > 1 && return nothing
+    qr = sqrt(1 - r2)
+    R = @SMatrix([1 - 2*(qy^2 + qz^2)  2*(qx*qy - qz*qr)    2*(qx*qz + qy*qr);
+                  2*(qx*qy + qz*qr)    1 - 2*(qx^2 + qz^2)  2*(qy*qz - qx*qr);
+                  2*(qx*qz - qy*qr)    2*(qy*qz + qx*qr)    1 - 2*(qx^2 + qy^2)])
+    return LinearMap(RotMatrix(R))
 end
-function rot(thetas, img::AbstractArray{T,3}, SD=I) where {T}
-    length(thetas) == 3 || throw(DimensionMismatch("expected 3 parameters, got $(length(thetas))"))
-    θx, θy, θz = thetas
-    rotm = RotMatrix(RotXYZ(θx,θy,θz))
-    SDS = SMatrix{3,3}(SD)
-    rotm = SDS\rotm*SDS
-    return LinearMap(SMatrix{3,3}(rotm))
+
+#rotation + translation
+tfmrigid(dx::Number, dy::Number, θ::Number) = Translation(dx, dy) ∘ rot(θ)
+
+tfmrigid(dx::Number, dy::Number, dz::Number, qx::Number, qy::Number, qz::Number) =
+    Translation(dx, dy, dz) ∘ rot(qx, qy, qz)
+
+## Transformations supplied as vectors, for which we pass the array so we can infer the dimensionality
+
+@noinline dimcheck(v, lv) = length(v) == lv || throw(DimensionMismatch("expected $lv parameters, got $(length(v))"))
+
+function rot(theta, img::AbstractArray{T,2}) where {T}
+    dimcheck(theta, 1)
+    return rot(theta[1])
 end
+
+function rot(qs, img::AbstractArray{T,3}) where {T}
+    dimcheck(qs, 3)
+    qx, qy, qz = qs
+    return rot(qx, qy, qz)
+end
+
+function tfmrigid(params, img::AbstractArray{T,2}) where {T}
+    dimcheck(params, 3)
+    dx, dy, θ = params
+    return tfmrigid(dx, dy, θ)
+end
+
+function tfmrigid(params, img::AbstractArray{T,3}) where {T}
+    dimcheck(params, 6)
+    dx, dy, dz, qx, qy, qz = params
+    return tfmrigid(dx, dy, dz, qx, qy, qz)
+end
+
+## Computing mismatch
 
 #rotation + shift, fast because it uses fourier method for shift
 function rigid_mm_fast(theta, mxshift, fixed, moving, thresh, SD; initial_tfm=IdentityTransformation())
-    tfm = initial_tfm ∘ rot(theta, moving, update_SD(SD, initial_tfm))
+    tfm = arrayscale(initial_tfm ∘ rot(theta, moving), SD)
     moving, fixed = warp_and_intersect(moving, fixed, tfm)
     bshft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity)
     return mm
 end
 
-#rotation + translation
-function tfmrigid(params, img::AbstractArray{T,2}, SD=Matrix(1.0*I,2,2)) where {T}
-    length(params) == 3 || throw(DimensionMismatch("expected 3 parameters, got $(length(params))"))
-    dx, dy, θ = params
-    rt = rot(θ, img, SD)
-    return Translation(dx, dy) ∘ rt
-end
-function tfmrigid(params, img::AbstractArray{T,3}, SD=Matrix(1.0*I,3,3)) where {T}
-    length(params) == 6 || throw(DimensionMismatch("expected 6 parameters, got $(length(params))"))
-    dx, dy, dz, θx, θy, θz =  params
-    rt = rot((θx, θy, θz), img, SD)
-    return Translation(dx, dy, dz) ∘ rt
-end
 #rotation + shift, slow because it warps for every rotation and shift
 function rigid_mm_slow(params, fixed, moving, thresh, SD; initial_tfm=IdentityTransformation())
-    tfm = initial_tfm ∘ tfmrigid(params, moving, update_SD(SD, initial_tfm))
+    tfm = arrayscale(initial_tfm ∘ tfmrigid(params, moving), SD)
     moving, fixed = warp_and_intersect(moving, fixed, tfm)
     mm = mismatch0(fixed, moving; normalization=:intensity)
     return ratio(mm, thresh, Inf)
@@ -59,9 +92,9 @@ function qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD;
     root_coarse, x0coarse = _analyze(f, lower, upper;
                                      minwidth=minwidth_rot, print_interval=100, maxevals=5e4, kwargs..., atol=0, rtol=1e-3)
     box_coarse = minimum(root_coarse)
-    tfmcoarse0 = initial_tfm ∘ rot(position(box_coarse, x0coarse), moving, update_SD(SD, initial_tfm))
-    best_shft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=tfmcoarse0)
-    tfmcoarse = tfmcoarse0 ∘ Translation(best_shft)
+    tfmcoarse0 = initial_tfm ∘ rot(position(box_coarse, x0coarse), moving)
+    best_shft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=arrayscale(tfmcoarse0, SD))
+    tfmcoarse = tfmcoarse0 ∘ pscale(Translation(best_shft), SD)
     return tfmcoarse, mm
 end
 
@@ -78,33 +111,63 @@ function qd_rigid_fine(fixed, moving, mxrot, minwidth_rot, SD;
     minwidth = vcat(minwidth_shfts, minwidth_rot)
     root, x0 = _analyze(f, lower, upper; minwidth=minwidth, print_interval=100, maxevals=5e4, kwargs...)
     box = minimum(root)
-    tfmfine = initial_tfm ∘ tfmrigid(position(box, x0), moving, update_SD(SD, initial_tfm))
+    tfmfine = initial_tfm ∘ tfmrigid(position(box, x0), moving)
     return tfmfine, value(box)
 end
 
 """
-`tform, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=I;  thresh=thresh, initial_tfm=IdentityTransformation(), kwargs...)`
-optimizes a rigid transformation (rotation + shift) to minimize the mismatch between `fixed` and
-`moving` using the QuadDIRECT algorithm.  The algorithm is run twice: the first step uses a fourier method to speed up
-the search for the best whole-pixel shift.  The second step refines the search for sub-pixel accuracy. `kwargs...` can include any
-keyword argument that can be passed to `QuadDIRECT.analyze`. It's recommended that you pass your own stopping criteria when possible
-(i.e. `rtol`, `atol`, and/or `fvalue`).  If you provide `rtol` and/or `atol` they will apply only to the second (fine) step of the registration;
-the user may not adjust these criteria for the coarse step.
+    tform, mm = qd_rigid(fixed, moving, mxshift, mxrot;
+                         SD=I, minwidth_rot=default_minwidth_rot(fixed, SD),
+                         thresh=thresh, initial_tfm=IdentityTransformation(), kwargs...)
 
-The rotation returned will be centered on the origin-of-coordinates, i.e. (0,0) for a 2D image.  Usually it is more natural to consider rotations
-around the center of the image.  If you would like `mxrot` and the returned rotation to act relative to the center of the image, then you must
-move the origin to the center of the image by calling `centered(img)` from the `ImageTransformations` package.  Call `centered` on both the
-fixed and moving image to generate the `fixed` and `moving` that you provide as arguments.  If you later want to apply the returned transform
-to an image you must remember to call `centered` on that image as well.  Alternatively you can re-encode the transformation in terms of a
+Optimize a rigid transformation (rotation + shift) to minimize the mismatch between `fixed` and
+`moving` using the QuadDIRECT algorithm.  The algorithm is run twice: the first step finds the optimal rotation,
+using a fourier method to speed up the search for the best whole-pixel shift.
+The second step performs the rotation + shift in combination to obtain sub-pixel accuracy.
+Any `NaN`-valued pixels are not included in the mismatch; you can use this to mask out
+any regions of `fixed` that you don't want to align against.
+
+`mxshift` is the maximum-allowed translation, in units of array indices. It can be passed
+as a vector or tuple.
+`mxrot` is the maximum-allowed rotation, in radians for 2d or
+[quaternion-units](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation) for 3d.
+See [`RegisterQD.rot`](@ref) for more information.
+`minwidth_rot` optionally specifies the lower limit of resolution for the rotation;
+the default is a rotation that moves corner elements by 0.1 pixel.
+
+`kwargs...` can include any keyword argument that can be passed to `QuadDIRECT.analyze`.
+It's recommended that you pass your own stopping criteria when possible
+(i.e. `rtol`, `atol`, and/or `fvalue`).
+If you provide `rtol` and/or `atol` they will apply only to the second (fine) step of the registration;
+there is currently no way to adjust these criteria for the coarse step.
+
+The rotation returned will be centered on the origin-of-coordinates, i.e. (0,0) for a 2D image.
+Usually it is more natural to consider rotations around the center of the image.
+If you would like `mxrot` and the returned rotation to act relative to the center of the image,
+then you must move the origin to the center of the image by calling `centered(img)` from the
+`ImageTransformations` package.
+Call `centered` on both the fixed and moving image to generate the `fixed` and `moving` that you provide as arguments.
+If you later want to apply the returned transform to an image you must remember to call `centered`
+on that image as well.  Alternatively you can re-encode the transformation in terms of a
 different origin by calling `recenter(tform, newctr)` where `newctr` is the displacement of the new center from the old center.
 
 Use `SD` if your axes are not uniformly sampled, for example `SD = diagm(voxelspacing)` where `voxelspacing`
-is a vector encoding the spacing along all axes of the image. `thresh` enforces a certain amount of sum-of-squared-intensity overlap between
-the two images; with non-zero `thresh`, it is not permissible to "align" the images by shifting one entirely out of the way of the other.
+is a vector encoding the spacing along all axes of the image.
+See [`arrayscale`](@ref) for more information about `SD`.
+
+`thresh` enforces a certain amount of sum-of-squared-intensity overlap between
+the two images; with non-zero `thresh`, it is not permissible to "align" the images by
+shifting one entirely out of the way of the other. The default value for `thresh` is 10%
+of the sum-of-squared-intensity of `fixed`.
 
 If you have a good initial guess at the solution, pass it with the `initial_tfm` kwarg to jump-start the search.
+
+Both the output `tfm` and any `initial_tfm` are represented in *physical* coordinates;
+as long as `initial_tfm` is a rigid transformation, `tfm` will be a pure rotation+translation.
+If `SD` is not the identity, use `arrayscale` before applying the result to `moving`.
 """
-function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=Matrix(1.0*I, ndims(fixed), ndims(fixed));
+function qd_rigid(fixed, moving, mxshift, mxrot, SD=I;
+                  minwidth_rot=default_minwidth_rot(CartesianIndices(fixed), SD),
                   thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                   initial_tfm=IdentityTransformation(),
                   print_interval=100,
@@ -113,7 +176,7 @@ function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=Matrix(1.0*I, 
     mxrot = [mxrot...]
     print_interval < typemax(Int) && print("Running coarse step\n")
     tfm_coarse, mm_coarse = qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD; initial_tfm=initial_tfm, thresh=thresh, print_interval=print_interval, kwargs...)
-    print_interval < typemax(Int) && print("Running fine step\n")
+    print_interval < typemax(Int) && print("Obtained mismatch $mm_coarse from coarse step, running fine step\n")
     final_tfm, mm_fine = qd_rigid_fine(fixed, moving, mxrot./2, minwidth_rot, SD; initial_tfm=tfm_coarse, thresh=thresh, print_interval=print_interval, kwargs...)
     return final_tfm, mm_fine
 end

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -151,8 +151,9 @@ If you later want to apply the returned transform to an image you must remember 
 on that image as well.  Alternatively you can re-encode the transformation in terms of a
 different origin by calling `recenter(tform, newctr)` where `newctr` is the displacement of the new center from the old center.
 
-Use `SD` if your axes are not uniformly sampled, for example `SD = diagm(voxelspacing)` where `voxelspacing`
-is a vector encoding the spacing along all axes of the image.
+Use `SD` ("spatial displacements") if your axes are not uniformly sampled, for example
+`SD = diagm(voxelspacing)` where `voxelspacing` is a vector encoding the spacing along all axes
+of the image.
 See [`arrayscale`](@ref) for more information about `SD`.
 
 `thresh` enforces a certain amount of sum-of-squared-intensity overlap between
@@ -166,7 +167,8 @@ Both the output `tfm` and any `initial_tfm` are represented in *physical* coordi
 as long as `initial_tfm` is a rigid transformation, `tfm` will be a pure rotation+translation.
 If `SD` is not the identity, use `arrayscale` before applying the result to `moving`.
 """
-function qd_rigid(fixed, moving, mxshift, mxrot, SD=I;
+function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike};
+                  SD::AbstractMatrix=I,
                   minwidth_rot=default_minwidth_rot(CartesianIndices(fixed), SD),
                   thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                   initial_tfm=IdentityTransformation(),

--- a/src/rigid.jl
+++ b/src/rigid.jl
@@ -82,7 +82,7 @@ function rigid_mm_slow(params, fixed, moving, thresh, SD; initial_tfm=IdentityTr
 end
 
 function qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot;
-                         SD=diagm(ones(ndims(fixed))),
+                         SD=I,
                          initial_tfm=IdentityTransformation(),
                          thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                          kwargs...)
@@ -100,7 +100,7 @@ function qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot;
 end
 
 function qd_rigid_fine(fixed, moving, mxrot, minwidth_rot;
-                       SD=diagm(ones(ndims(fixed))),
+                       SD=I,
                        initial_tfm=IdentityTransformation(),
                        thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                        kwargs...)
@@ -170,7 +170,7 @@ as long as `initial_tfm` is a rigid transformation, `tfm` will be a pure rotatio
 If `SD` is not the identity, use `arrayscale` before applying the result to `moving`.
 """
 function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike};
-                  SD=diagm(ones(ndims(fixed))),
+                  SD=I,
                   minwidth_rot=default_minwidth_rot(CartesianIndices(fixed), SD),
                   thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                   initial_tfm=IdentityTransformation(),

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,25 +3,67 @@ function warp_and_intersect(moving, fixed, tfm::IdentityTransformation)
         return moving, fixed
     end
     inds = intersect.(axes(moving), axes(fixed))
-    #TODO: use views after BlockRegistration #83 on Github is addressed
-    return moving[inds...], fixed[inds...]
+    return view(moving, inds...), view(fixed, inds...)
 end
 
 function warp_and_intersect(moving, fixed, tfm)
     moving = warp(moving, tfm)
     inds = intersect.(axes(moving), axes(fixed))
-    #TODO: use views after BlockRegistration #83 on Github is addressed
-    return moving[inds...], fixed[inds...]
+    return view(moving, inds...), view(fixed, inds...)
 end
 
-#Finds the best shift aligning moving to fixed, possibly after an initial transformation `initial_tfm`
-#The shift returned should be composed with initial_tfm later to create the full transform
+"""
+    I, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=IdentityTransformation())
+
+Find the best shift `I` (expressed as a tuple) aligning `moving` to `fixed`,
+possibly after an initial transformation `initial_tfm` applied to `moving`.
+`mm` is the sum-of-square errors at shift `I`.
+`mxshift` represents the maximum allowed shift, in pixels.
+`thresh` is a threshold on the minimum allowed overlap between `fixed` and the shifted `moving`,
+expressed in pixels if `normalization=:pixels` and in sum-of-squared-intensity if `normalization=:intensity`.
+
+One can compute an overall transformation by composing `initial_tfm` with the returned shift `I`.
+"""
 function best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=IdentityTransformation())
     moving, fixed = warp_and_intersect(moving, fixed, initial_tfm)
     mms = mismatch(fixed, moving, mxshift; normalization=normalization)
     best_i = indmin_mismatch(mms, thresh)
-    return best_i.I, ratio(mms[best_i], 0.0, Inf)
+    mm = mms[best_i]
+    return best_i.I, ratio(mm, thresh, typemax(eltype(mm)))
 end
+
+"""
+    itfm = arrayscale(ptfm, SD)
+
+Convert the physical-space transformation `ptfm` into one, `itfm`, that operates on index-space
+for arrays.
+For example, suppose `ptfm` is a pure 3d rotation, but you want to apply it to an array
+in which the sampling along the three axes is (0.5mm, 0.5mm, 2mm). Then by setting
+`SD = Diagonal(SVector(1, 1, 4))` (the ratio of scales along each axis),
+one obtains an `itfm` suitable for warping the array.
+
+Any translational component of `ptfm` is interpreted in physical-space units, not index-units.
+
+`SD` does not even have to be diagonal, if the array sampling is skewed.
+The columns of `SD` should correspond to the physical-coordinate displacement
+achieved by shifting by one array element along each axis of the array.
+Specifically, `SD[:,j]` should be the physical displacement of one array voxel along dimension `j`.
+"""
+arrayscale(ptfm::AbstractAffineMap, SD::AbstractMatrix) =
+    arrayscale(ptfm, LinearMap(SD))
+
+arrayscale(ptfm::AbstractAffineMap, scale::LinearMap) =
+    inv(scale) ∘ ptfm ∘ scale
+
+"""
+    pt = pscale(it, SD)
+
+Convert an index-scaled translation `it` into a physical-space translation `pt`.
+See [`arrayscale`](@ref) for more information.
+"""
+pscale(t::Translation, SD::AbstractMatrix) = pscale(t, LinearMap(SD))
+pscale(t::Translation, scale::LinearMap) = Translation(scale(t.translation))
+
 
 #returns new minbounds and maxbounds with range sizes change by fac
 function scalebounds(minb, maxb, fac::Real)
@@ -66,6 +108,25 @@ function default_lin_minwidths(img::AbstractArray{T,N}; dmin=1e-5, ndmin=1e-5) w
         mat[i,i] = abs(dmin)
     end
     return mat[:]
+end
+
+function default_minwidth_rot(I::CartesianIndices{2}, SD; d=0.1)
+    θ = Inf
+    T = SD \ (@SMatrix([0 -1; 1 0]) * SD)  # I + [0 -Δθ; Δθ 0] is a rotmtrx for infinitesimal Δθ
+    for c in CornerIterator(I)
+        Δc = T*SVector(Tuple(c))
+        for dc in Δc
+            θ = min(θ, abs(d/dc))
+        end
+    end
+    return (θ,)
+end
+
+function default_minwidth_rot(I::CartesianIndices{3}, SD; d=0.1)
+    slice2d(I, i1, i2) = CartesianIndices((I.indices[i1], I.indices[i2]))
+    return (default_minwidth_rot(slice2d(I, 2, 3), SD[2:3, 2:3]; d=d),
+            default_minwidth_rot(slice2d(I, 1, 3), SD[[1,3], [1,3]]; d=d),
+            default_minwidth_rot(slice2d(I, 1, 2), SD[1:2, 1:2]; d=d))
 end
 
 #sets splits based on lower and upper bounds

--- a/src/util.jl
+++ b/src/util.jl
@@ -55,6 +55,9 @@ arrayscale(ptfm::AbstractAffineMap, SD::AbstractMatrix) =
 arrayscale(ptfm::AbstractAffineMap, scale::LinearMap) =
     inv(scale) ∘ ptfm ∘ scale
 
+arrayscale(ptfm::AbstractAffineMap, scale::UniformScaling) = ptfm
+
+
 """
     pt = pscale(it, SD)
 
@@ -63,6 +66,7 @@ See [`arrayscale`](@ref) for more information.
 """
 pscale(t::Translation, SD::AbstractMatrix) = pscale(t, LinearMap(SD))
 pscale(t::Translation, scale::LinearMap) = Translation(scale(t.translation))
+pscale(t::Translation, scale::UniformScaling) = Translation(scale.λ*t.translation)
 
 
 #returns new minbounds and maxbounds with range sizes change by fac

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -57,7 +57,7 @@ using Test, TestImages
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
     tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0, fvalue=1e-8)
-
+    tfm = arrayscale(tfm, SD)
     @test sum(abs.(tfm0.linear - tfm.linear)) < 1e-3
 
     #3D
@@ -74,7 +74,7 @@ using Test, TestImages
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
     tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0)
-
+    tfm = arrayscale(tfm, SD)
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(RotXYZ(tfm.linear)[:], tfm.translation))) < 0.1
 
 #NOTE: the 2D test below fails rarely and the 3D test fails often, apparently because full affine is too difficult with these images
@@ -94,57 +94,57 @@ using Test, TestImages
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
     tfm, mm = qd_affine(fixed, moving, mxshift; SD=SD, thresh=thresh, maxevals=1500, rtol=0, fvalue=1e-6)
-
+    tfm = arrayscale(tfm, SD)
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
 
-    #The tests below fail.  Probably two factors contributing to failure:
-    # 1) Full affine 3D is a lot of parameters so it's just difficuilt (12 parameters)
-    # 2) The current way of computing mismatch may be flawed for scaling transformations
-    #    because the algorithm output shows it tends to compress/expand the image in order to remove
-    #    pixels from the denominator in the mismatch calculation (especially bad for small images).
-    #3D
-    #moving = centered(rand(20,20,20));
-    #shft = SArray{Tuple{3}}(2.6, 0.1, -3.3);
-    ##random displacement from the identity matrix
-    #mat = SArray{Tuple{3,3}}(eye(3) + rand(3,3)./30 + -rand(3,3)./30);
-    #tfm0 = AffineMap(mat, shft); #ground truth
-    #newfixed = warp(moving, tfm0);
-    #inds = intersect.(axes(moving), axes(newfixed))
-    #fixed = newfixed[inds...]
-    #moving = moving[inds...]
-    #thresh = 0.1 * (sum(abs2.(fixed[.!(isnan.(fixed))]))+sum(abs2.(moving[.!(isnan.(moving))])));
-    #mxshift = (10,10,10)
-    #SD = eye(ndims(fixed));
+        #The tests below fail.  Probably two factors contributing to failure:
+        # 1) Full affine 3D is a lot of parameters so it's just difficuilt (12 parameters)
+        # 2) The current way of computing mismatch may be flawed for scaling transformations
+        #    because the algorithm output shows it tends to compress/expand the image in order to remove
+        #    pixels from the denominator in the mismatch calculation (especially bad for small images).
+        #3D
+        #moving = centered(rand(20,20,20));
+        #shft = SArray{Tuple{3}}(2.6, 0.1, -3.3);
+        ##random displacement from the identity matrix
+        #mat = SArray{Tuple{3,3}}(eye(3) + rand(3,3)./30 + -rand(3,3)./30);
+        #tfm0 = AffineMap(mat, shft); #ground truth
+        #newfixed = warp(moving, tfm0);
+        #inds = intersect.(axes(moving), axes(newfixed))
+        #fixed = newfixed[inds...]
+        #moving = moving[inds...]
+        #thresh = 0.1 * (sum(abs2.(fixed[.!(isnan.(fixed))]))+sum(abs2.(moving[.!(isnan.(moving))])));
+        #mxshift = (10,10,10)
+        #SD = eye(ndims(fixed));
 
-    #tfm, mm = qd_affine(centered(fixed), centered(moving), mxshift, SD; thresh=thresh, rtol=0, fvalue=1e-4);
+        #tfm, mm = qd_affine(centered(fixed), centered(moving), mxshift, SD; thresh=thresh, rtol=0, fvalue=1e-4);
 
-    #@test mm <= 1e-4
-    #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
+        #@test mm <= 1e-4
+        #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
 
-    #not random
-    #moving = zeros(10,10,10);
-    #moving[5:7, 5:7, 5:7] = 1.0
-    #moving = centered(moving)
-    #shft = SArray{Tuple{3}}(0.6, 0.1, -0.3);
-    ##random displacement from the identity matrix
-    #mat = SArray{Tuple{3,3}}(eye(3) + rand(3,3)./50 + -rand(3,3)./50);
-    #tfm00 = AffineMap(mat, shft);
-    ##tfm0 = recenter(tfm00, center(moving)); #ground truth
-    #tfm0 = tfm00 #ground truth
-    #newfixed = warp(moving, tfm0);
-    #inds = intersect.(axes(moving), axes(newfixed))
-    #fixed = newfixed[inds...]
-    #moving = moving[inds...]
-    #thresh = 0.5 * sum(abs2.(fixed[.!(isnan.(fixed))]));
-    #mxshift = (5,5,5)
-    #SD = eye(ndims(fixed));
-    #@test RegisterOptimize.aff(vcat(tfm00.translation[:], tfm00.linear[:]), fixed, SD) == tfm0
+        #not random
+        #moving = zeros(10,10,10);
+        #moving[5:7, 5:7, 5:7] = 1.0
+        #moving = centered(moving)
+        #shft = SArray{Tuple{3}}(0.6, 0.1, -0.3);
+        ##random displacement from the identity matrix
+        #mat = SArray{Tuple{3,3}}(eye(3) + rand(3,3)./50 + -rand(3,3)./50);
+        #tfm00 = AffineMap(mat, shft);
+        ##tfm0 = recenter(tfm00, center(moving)); #ground truth
+        #tfm0 = tfm00 #ground truth
+        #newfixed = warp(moving, tfm0);
+        #inds = intersect.(axes(moving), axes(newfixed))
+        #fixed = newfixed[inds...]
+        #moving = moving[inds...]
+        #thresh = 0.5 * sum(abs2.(fixed[.!(isnan.(fixed))]));
+        #mxshift = (5,5,5)
+        #SD = eye(ndims(fixed));
+        #@test RegisterOptimize.aff(vcat(tfm00.translation[:], tfm00.linear[:]), fixed, SD) == tfm0
 
-    #tfm, mm = qd_affine(centered(fixed), centered(moving), mxshift, SD; thresh=thresh, rtol=0, fvalue=1e-4);
+        #tfm, mm = qd_affine(centered(fixed), centered(moving), mxshift, SD; thresh=thresh, rtol=0, fvalue=1e-4);
 
-    #@test mm <= 1e-4
-    #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
-
+        #@test mm <= 1e-4
+        #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
+    #TODO this test passes if run individually, but breaks when included in the testset.
 end #tests with random images
 
 @testset "Suppression of printing" begin

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -93,7 +93,7 @@ using Test, TestImages
     mxshift = (5,5)
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_affine(fixed, moving, mxshift, SD; thresh=thresh, maxevals=1500, rtol=0, fvalue=1e-6)
+    tfm, mm = qd_affine(fixed, moving, mxshift; SD=SD, thresh=thresh, maxevals=1500, rtol=0, fvalue=1e-6)
 
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
 
@@ -152,7 +152,7 @@ end #tests with random images
     ca, cb = centered(a), centered(b)
     mxshift = (2,2)
     mxrot = 0.5
-    minwidth_rot = 1e-3
+    # minwidth_rot = 1e-3
     mktemp() do path, io
         redirect_stdout(io) do
             qd_translate(a, b, (2,2); print_interval=typemax(Int))

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -93,7 +93,7 @@ using Test, TestImages
     mxshift = (5,5)
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_affine(fixed, moving, mxshift; SD=SD, thresh=thresh, maxevals=1500, rtol=0, fvalue=1e-6)
+    tfm, mm = qd_affine(fixed, moving, mxshift; SD=SD, thresh=thresh, rtol=0, fvalue=1e-3, maxevals=10^4)
     tfm = arrayscale(tfm, SD)
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
 

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -2,6 +2,7 @@ using StaticArrays, Interpolations
 using Images, CoordinateTransformations, Rotations
 using RegisterMismatch
 using RegisterQD
+using Random
 
 #import BlockRegistration, RegisterOptimize
 #using RegisterCore, RegisterPenalty, RegisterDeformation, RegisterMismatch, RegisterFit
@@ -9,6 +10,8 @@ using RegisterQD
 using Test, TestImages
 
 @testset "QuadDIRECT tests with random images" begin
+    Random.seed!(879)
+
     ##### Translations
     #2D
     moving = rand(50,50)

--- a/test/qd_random.jl
+++ b/test/qd_random.jl
@@ -56,7 +56,7 @@ using Test, TestImages
     minwidth_rot = [0.0002]
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, maxevals=1000, rtol=0, fvalue=1e-8)
+    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0, fvalue=1e-8)
 
     @test sum(abs.(tfm0.linear - tfm.linear)) < 1e-3
 
@@ -73,7 +73,7 @@ using Test, TestImages
     minwidth_rot = fill(0.0002, 3)
     SD = SDiagonal(@SVector(ones(ndims(fixed))))
 
-    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, maxevals=1000, rtol=0)
+    tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot; SD=SD, thresh=thresh, maxevals=1000, rtol=0)
 
     @test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(RotXYZ(tfm.linear)[:], tfm.translation))) < 0.1
 
@@ -120,7 +120,7 @@ using Test, TestImages
 
     #@test mm <= 1e-4
     #@test sum(abs.(vcat(tfm0.linear[:], tfm0.translation) - vcat(tfm.linear[:], tfm.translation))) < 0.1
-    
+
     #not random
     #moving = zeros(10,10,10);
     #moving[5:7, 5:7, 5:7] = 1.0
@@ -156,7 +156,7 @@ end #tests with random images
     mktemp() do path, io
         redirect_stdout(io) do
             qd_translate(a, b, (2,2); print_interval=typemax(Int))
-            qd_rigid(ca, cb, mxshift, mxrot, minwidth_rot; print_interval=typemax(Int))
+            qd_rigid(ca, cb, mxshift, mxrot; print_interval=typemax(Int))
             qd_affine(ca, cb, mxshift; print_interval=typemax(Int))
         end
         flush(io)

--- a/test/qd_standard.jl
+++ b/test/qd_standard.jl
@@ -42,7 +42,7 @@ end
 @testset "QuadDIRECT tests with standard images" begin
     img = testimage("cameraman");
 
-    #Translation (subpixel)
+#Translation (subpixel)
     tfm = Translation(@SVector([14.3, 17.6]))
     fixed, moving = fixedmov(img, tfm)
     mxshift = (100,100) #make sure this isn't too small
@@ -73,7 +73,7 @@ end
     tfm = AffineMap(tfm.linear*scale, tfm.translation)
     mxshift = (100,100) #make sure this isn't too small
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_affine(fixed, moving, mxshift, SD; maxevals=1000, rtol=0, fvalue=0.0002)
+    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=1000, rtol=0, fvalue=0.0002)
     tfmtest(tfm, tform)
 
     #with anisotropic sampling
@@ -82,6 +82,6 @@ end
     scale = @SMatrix [1.005 0; 0 0.995]
     tfm = AffineMap(tfm.linear*scale, tfm.translation)
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_affine(fixed, moving, mxshift, SD; maxevals=1000, rtol=0, fvalue=0.0002)
+    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=1000, rtol=0, fvalue=0.0002)
     tfmtest(tfm, tform)
 end #tests with standard images

--- a/test/qd_standard.jl
+++ b/test/qd_standard.jl
@@ -47,7 +47,7 @@ end
     mxshift = (100,100) #make sure this isn't too small
     tform, mm = qd_translate(fixed, moving, mxshift; maxevals=1000, rtol=0, fvalue=0.0003)
     tfmtest(tfm, tform)
-    
+
     #Rigid transform
     SD = Matrix{Float64}(LinearAlgebra.I, 2, 2)
     tfm = Translation(@SVector([14, 17]))∘LinearMap(RotMatrix(0.3)) #no distortion for now
@@ -55,14 +55,14 @@ end
     mxshift = (100,100) #make sure this isn't too small
     mxrot = (0.5,)
     minwidth_rot = fill(0.002, 3)
-    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot, minwidth_rot, SD; maxevals=1000, rtol=0, fvalue=0.0002)
+    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot; SD=SD, maxevals=1000, rtol=0, fvalue=0.0002)
     tfmtest(tfm, tform)
     #with anisotropic sampling
     SD = Matrix(Diagonal([0.5; 1.0]))
     tfm = Translation(@SVector([14.3, 17.8]))∘LinearMap(SD\RotMatrix(0.3)*SD)
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot, minwidth_rot, SD; maxevals=1000, rtol=0, fvalue=0.0002)
-    tfmtest(tfm, tform)
+    tform, mm = qd_rigid(centered(fixed), centered(moving), mxshift, mxrot; SD=SD, maxevals=1000, rtol=0, fvalue=0.0002)
+    tfmtest(tfm, arrayscale(tform, SD))
 
     #Affine transform
     tfm = Translation(@SVector([14, 17]))∘LinearMap(RotMatrix(0.01))

--- a/test/qd_standard.jl
+++ b/test/qd_standard.jl
@@ -84,7 +84,7 @@ end
     tfm = AffineMap(tfm.linear*scale, tfm.translation)
     tfm = arrayscale(tfm, SD)
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=1000, rtol=0, fvalue=0.0002, ndmax = 0.25)
-    tform2 = arrayscale(tform, SD) 
+    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=10000, rtol=0, fvalue=0.0002, ndmax = 0.25)
+    tform2 = arrayscale(tform, SD)
     tfmtest(tfm, tform2)
 end #tests with standard images

--- a/test/qd_standard.jl
+++ b/test/qd_standard.jl
@@ -1,3 +1,4 @@
+using ImageMagick
 using StaticArrays, Interpolations, LinearAlgebra
 using Images, CoordinateTransformations, Rotations
 using OffsetArrays
@@ -42,7 +43,7 @@ end
 @testset "QuadDIRECT tests with standard images" begin
     img = testimage("cameraman");
 
-#Translation (subpixel)
+    #Translation (subpixel)
     tfm = Translation(@SVector([14.3, 17.6]))
     fixed, moving = fixedmov(img, tfm)
     mxshift = (100,100) #make sure this isn't too small
@@ -78,10 +79,12 @@ end
 
     #with anisotropic sampling
     SD = Matrix(Diagonal([0.5; 1.0]))
-    tfm = Translation(@SVector([14.3, 17.8]))∘LinearMap(SD\RotMatrix(0.01)*SD)
+    tfm = Translation(@SVector([14.3, 17.8]))∘LinearMap(RotMatrix(0.1)) #Translation(@SVector([14.3, 17.8]))∘LinearMap(SD\RotMatrix(0.01)*SD)
     scale = @SMatrix [1.005 0; 0 0.995]
     tfm = AffineMap(tfm.linear*scale, tfm.translation)
+    tfm = arrayscale(tfm, SD)
     fixed, moving = fixedmov(centered(img), tfm)
-    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=1000, rtol=0, fvalue=0.0002)
-    tfmtest(tfm, tform)
+    tform, mm = qd_affine(fixed, moving, mxshift; SD = SD, maxevals=1000, rtol=0, fvalue=0.0002, ndmax = 0.25)
+    tform2 = arrayscale(tform, SD) 
+    tfmtest(tfm, tform2)
 end #tests with standard images

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ImageMagick
 using RegisterQD
 using Test
 
+include("util.jl")
 include("qd_random.jl")
 include("qd_standard.jl")
 include("gridsearch.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,16 @@
+@testset "default_minwidth_rot" begin
+    img = rand(3, 10)
+    ci = CartesianIndices(img)
+    θ = RegisterQD.default_minrot(ci)
+    @test θ ≈ 0.01 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [1 0; 0 2])
+    @test θ ≈ 0.005 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [3 0; 0 1])
+    @test θ ≈ 0.007 rtol=0.1
+    θ = RegisterQD.default_minrot(ci, [10 0; 0 1])
+    @test θ ≈ 0.01/3 rtol=0.1
+    img = rand(3, 10, 5)
+    ci = CartesianIndices(img)
+    θ = RegisterQD.default_minrot(ci)
+    @test θ ≈ 0.1/sqrt(3^2 + 10^2 + 5^2) rtol=1e-3
+end

--- a/test/util.jl
+++ b/test/util.jl
@@ -17,3 +17,6 @@ end
 
 #TODO add a testset for other support functions
 #rotations
+#arrayscale
+#pscale
+#restrict

--- a/test/util.jl
+++ b/test/util.jl
@@ -14,3 +14,6 @@
     θ = RegisterQD.default_minrot(ci)
     @test θ ≈ 0.1/sqrt(3^2 + 10^2 + 5^2) rtol=1e-3
 end
+
+#TODO add a testset for other support functions
+#rotations


### PR DESCRIPTION
This incorporates #11 and #12, fixes the DOS line endings, and adds a `NEWS.md` about breaking changes and expands the `README`.

CC @ChantalJuntao 