### PR TITLE
Add "cheap" smoothing (fixes #7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,9 @@ CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 QuadDIRECT = "dae52e8d-d666-5120-a592-9e15c33b8d7a"
 RegisterCore = "67712758-55e7-5c3c-8e85-dda1d7758434"
 RegisterDeformation = "c19381b7-cf49-59d7-881c-50dfbd227eaf"
@@ -16,9 +18,9 @@ RegisterMismatch = "3c0dd727-6833-5f5d-a1e8-c0d421935c74"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
-
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -27,4 +29,4 @@ TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test", "ImageMagick", "TestImages", "Random", "AxisArrays", "ImageMetadata", "Unitful"]
+test = ["Test", "ImageMagick", "TestImages", "Random", "AxisArrays", "ImageMetadata", "Unitful", "Distributions"]

--- a/src/RegisterQD.jl
+++ b/src/RegisterQD.jl
@@ -3,7 +3,7 @@ module RegisterQD
 using Images, CoordinateTransformations, QuadDIRECT
 using RegisterMismatch
 using RegisterCore #just for indmin_mismatch?
-using RegisterDeformation
+using RegisterDeformation, PaddedViews, MappedArrays
 using Rotations
 using Interpolations, CenterIndexedArrays, StaticArrays, OffsetArrays
 using LinearAlgebra
@@ -24,7 +24,8 @@ export qd_translate,
         arrayscale,
         grid_rotations,
         rotation_gridsearch,
-        getSD
+        getSD,
+        qsmooth
 
 # Deprecations
 function qd_rigid(fixed, moving, mxshift::VecLike, mxrot::Union{Number,VecLike}, minwidth_rot::VecLike, SD::AbstractMatrix=I; kwargs...)

--- a/src/translations.jl
+++ b/src/translations.jl
@@ -21,14 +21,14 @@ function qd_translate_fine(fixed, moving;
     f(x) = translate_mm_slow(x, fixed, moving, thresh; initial_tfm=initial_tfm)
     upper = fill(1.0, ndims(fixed))
     lower = -upper
-    root, x0 = _analyze(f, lower, upper; minwidth=minwidth, print_interval=100, maxevals=5e4, kwargs...)
+    root, x0 = _analyze(f, lower, upper; minwidth=minwidth, print_interval=100, kwargs...)
     box = minimum(root)
     tfmfine = initial_tfm ∘ tfmshift(position(box, x0), moving)
     return tfmfine, value(box)
 end
 
 """
-`tform, mm = qd_translate(fixed, moving, mxshift; thresh=thresh, kwargs...)`
+`tform, mm = qd_translate(fixed, moving, mxshift; presmoothed=false, thresh=thresh, kwargs...)`
 optimizes a simple shift (translation) to minimize the mismatch between `fixed` and
 `moving` using the QuadDIRECT algorithm with the constraint that no shifts larger than
 ``mxshift` will be considered.
@@ -39,23 +39,30 @@ algorithm need not be aware of anisotropic sampling.
 The algorithm involves two steps: the first step uses a fourier method to speed up
 the search for the best whole-pixel shift.  The second step refines the search for sub-pixel accuracy.
 The default precision of this step is 1% of one pixel (0.01) for each dimension of the image.
-You can override the default with the `minwidth` argument.  `kwargs...` can also include 
+You can override the default with the `minwidth` argument.  `kwargs...` can also include
 any other keyword argument that can be passed to `QuadDIRECT.analyze`.
 It's recommended that you pass your own stopping criteria when possible (i.e. `rtol`, `atol`, and/or `fvalue`).
+
+Use `presmoothed=true` if you have called [`qsmooth`](@ref) on `fixed` before calling `qd_affine`.
+Do not smooth `moving`.
 
 If you have a good initial guess at the solution, pass it with the `initial_tfm` kwarg to jump-start the search.
 `thresh` enforces a certain amount of sum-of-squared-intensity overlap between the two images;
 with non-zero `thresh`, it is not permissible to "align" the images by shifting one entirely out of the way of the other.
 
-If the `crop` keyword arg is `true` then `fixed` is cropped by `mxshift` on all sides so that there will be 
+If the `crop` keyword arg is `true` then `fixed` is cropped by `mxshift` on all sides so that there will be
 complete overlap between `fixed` and `moving` for any evaluated shift. This avoids edge effects that can
 occur due to normalization when the transformed `moving` doesn't fully overlap with `fixed`.
 """
 function qd_translate(fixed, moving, mxshift;
+                      presmoothed=false,
                       thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])),
                       initial_tfm=IdentityTransformation(),
                       minwidth=fill(0.01, ndims(fixed)), print_interval=100, crop=false, kwargs...)
     fixed, moving = float(fixed), float(moving)
+    if presmoothed
+        moving = qinterp(eltype(fixed), moving)
+    end
     print_interval < typemax(Int) && print("Running coarse step\n")
     if crop
         #we enforce that moving is always bigger than fixed by amount 2*(maxshift+1) (the +1 is for the fine step)

--- a/test/util.jl
+++ b/test/util.jl
@@ -26,20 +26,20 @@ end
 @testset "getSD" begin
     #test that getSD deals with arbitrary dimensions
     A2 = rand(10,10)
-    @test getSD(A2) == diagm(ones(2))
+    @test getSD(A2) == I
 
     A3 = rand(10,10,10)
-    @test getSD(A3) == diagm(ones(3))
+    @test getSD(A3) == I
 
     A5 = rand(10,10,10,10,10)
-    @test getSD(A5) == diagm(ones(5))
+    @test getSD(A5) == I
 
     Ax3 = AxisArray(A3, 1:1:10, 1:2:20, 1:3:30)
-    @test getSD(Ax3) == diagm([1.0,2.0,3.0])
+    @test getSD(Ax3) == Diagonal([1.0,2.0,3.0])
 
     #test that getSD works with test images
     mri = testimage("mri-stack.tif")
-    @test getSD(mri) == diagm([1.0, 1.0, 5.0])
+    @test getSD(mri) == Diagonal([1.0, 1.0, 5.0])
 
     #test that getSD deals with images with arbitrary space directions
     skewed = ImageMeta(rand(10,10,10))
@@ -50,7 +50,7 @@ end
     #test that getSD can reconcile units of different magnitudes
     badsampling = AxisArray(rand(10,10,10), (:x,:y,:z), (1mm, 2km, 3.4cm))
     badsampling = ImageMeta(badsampling)
-    @test getSD(badsampling) == diagm([1, 2e6, 34])
+    @test getSD(badsampling) == Diagonal([1, 2e6, 34])
 
     #test that getSD ignores the time-axis
     timedarray = AxisArray(rand(10,10,10), (:x, :y, :time), (1μm, 1μm, 1s))

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,7 +1,9 @@
 using ImageMagick
 using TestImages
 using LinearAlgebra
-using AxisArrays, ImageMetadata
+using ImageMetadata
+import AxisArrays
+using AxisArrays: AxisArray, Axis
 using Unitful: μm, mm, cm, km, s
 
 @testset "default_minwidth_rot" begin


### PR DESCRIPTION
This takes the strategy of using interpolation to do the smoothing. If the user pre-smooths `fixed`, then "naive" interpolation of `moving` will perform the same smoothing. Especially if you're registering an image sequence to perform motion correction, this is a fairly cheap (computationally inexpensive) way to perform smoothing. Quadratic interpolation is more expensive than linear interpolation, of course, so in some cases you still may prefer to do all smoothing manually.

Use it like this:
```julia
sfixed = qsmooth(fixed)
tfm, mm = qd_some_registration(sfixed, moving, ...; presmoothed=true, ...)
```
(Don't call `qsmooth` on `moving`.)

Fixes #7